### PR TITLE
Add Expense Management tables

### DIFF
--- a/.AL-Go/settings.json
+++ b/.AL-Go/settings.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v7.2/settings.schema.json",
   "country": "us",
-  "appFolders": [],
+  "appFolders": [
+    "src"
+  ],
   "testFolders": [],
   "bcptTestFolders": []
 }

--- a/al.code-workspace
+++ b/al.code-workspace
@@ -2,6 +2,9 @@
     "folders": [
         {
             "path": ".AL-Go"
+        },
+        {
+            "path": "src"
         }
     ],
     "settings": {}

--- a/src/Tables/Employees.al
+++ b/src/Tables/Employees.al
@@ -1,0 +1,42 @@
+table 50101 Employees
+{
+    DataClassification = ToBeClassified;
+    fields
+    {
+        field(1; "Employee Id"; Code[20])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(2; "First Name"; Text[100])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(3; "Last Name"; Text[100])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(4; Email; Text[255])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(5; "Default Currency"; Code[3])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(6; "Legal Entity"; Code[10])
+        {
+            DataClassification = ToBeClassified;
+        }
+    }
+    keys
+    {
+        key(PK; "Employee Id")
+        {
+            Clustered = true;
+        }
+        key(Email; Email)
+        {
+            Unique = true;
+        }
+    }
+}

--- a/src/Tables/ExpenseCategories.al
+++ b/src/Tables/ExpenseCategories.al
@@ -1,0 +1,41 @@
+table 50104 "Expense Categories"
+{
+    DataClassification = ToBeClassified;
+    fields
+    {
+        field(1; "Category Code"; Code[20])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(2; Description; Text[255])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(3; "Expense Group Code"; Code[20])
+        {
+            DataClassification = ToBeClassified;
+            TableRelation = "Expense Groups"."Expense Group Code";
+        }
+        field(4; "Posting Group Code"; Code[20])
+        {
+            DataClassification = ToBeClassified;
+            TableRelation = "Expense Posting Groups"."Posting Group Code";
+        }
+        field(5; Refundable; Boolean)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(6; Active; Boolean)
+        {
+            DataClassification = ToBeClassified;
+            InitValue = true;
+        }
+    }
+    keys
+    {
+        key(PK; "Category Code")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/src/Tables/ExpenseComments.al
+++ b/src/Tables/ExpenseComments.al
@@ -1,0 +1,40 @@
+table 50116 "Expense Comments"
+{
+    DataClassification = ToBeClassified;
+    fields
+    {
+        field(1; "Comment Id"; BigInteger)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(2; "Report Id"; Code[30])
+        {
+            DataClassification = ToBeClassified;
+            TableRelation = "Expense Reports"."Report Id";
+        }
+        field(3; "Line Id"; BigInteger)
+        {
+            DataClassification = ToBeClassified;
+            TableRelation = "Expense Report Lines"."Line Id";
+        }
+        field(4; "Comment Text"; Text[1000])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(5; "Comment Date Time"; DateTime)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(6; "Created By"; Code[20])
+        {
+            DataClassification = ToBeClassified;
+        }
+    }
+    keys
+    {
+        key(PK; "Comment Id")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/src/Tables/ExpenseGroups.al
+++ b/src/Tables/ExpenseGroups.al
@@ -1,0 +1,22 @@
+table 50106 "Expense Groups"
+{
+    DataClassification = ToBeClassified;
+    fields
+    {
+        field(1; "Expense Group Code"; Code[20])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(2; Description; Text[255])
+        {
+            DataClassification = ToBeClassified;
+        }
+    }
+    keys
+    {
+        key(PK; "Expense Group Code")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/src/Tables/ExpenseItemizationLines.al
+++ b/src/Tables/ExpenseItemizationLines.al
@@ -1,0 +1,45 @@
+table 50112 "Expense Itemization Lines"
+{
+    DataClassification = ToBeClassified;
+    fields
+    {
+        field(1; "Itemization Line Id"; BigInteger)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(2; "Itemization Id"; BigInteger)
+        {
+            DataClassification = ToBeClassified;
+            TableRelation = "Expense Itemizations"."Itemization Id";
+        }
+        field(3; "Start Date"; Date)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(4; "End Date"; Date)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(5; Amount; Decimal)
+        {
+            DataClassification = ToBeClassified;
+            DecimalPlaces = 0 : 2;
+        }
+        field(6; Description; Text[255])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(7; "Expense Location Code"; Code[10])
+        {
+            DataClassification = ToBeClassified;
+            TableRelation = "Expense Locations"."Location Code";
+        }
+    }
+    keys
+    {
+        key(PK; "Itemization Line Id")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/src/Tables/ExpenseItemizations.al
+++ b/src/Tables/ExpenseItemizations.al
@@ -1,0 +1,33 @@
+table 50111 "Expense Itemizations"
+{
+    DataClassification = ToBeClassified;
+    fields
+    {
+        field(1; "Itemization Id"; BigInteger)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(2; "Line Id"; BigInteger)
+        {
+            DataClassification = ToBeClassified;
+            TableRelation = "Expense Report Lines"."Line Id";
+        }
+        field(3; "Total Amount"; Decimal)
+        {
+            DataClassification = ToBeClassified;
+            DecimalPlaces = 0 : 2;
+        }
+        field(4; "Total Reimbursable Amount"; Decimal)
+        {
+            DataClassification = ToBeClassified;
+            DecimalPlaces = 0 : 2;
+        }
+    }
+    keys
+    {
+        key(PK; "Itemization Id")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/src/Tables/ExpenseLocations.al
+++ b/src/Tables/ExpenseLocations.al
@@ -1,0 +1,26 @@
+table 50107 "Expense Locations"
+{
+    DataClassification = ToBeClassified;
+    fields
+    {
+        field(1; "Location Code"; Code[10])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(2; "Country Region Code"; Code[2])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(3; Description; Text[255])
+        {
+            DataClassification = ToBeClassified;
+        }
+    }
+    keys
+    {
+        key(PK; "Location Code")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/src/Tables/ExpenseManagementSetup.al
+++ b/src/Tables/ExpenseManagementSetup.al
@@ -1,0 +1,30 @@
+table 50100 "Expense Management Setup"
+{
+    DataClassification = ToBeClassified;
+    fields
+    {
+        field(1; "Setup Id"; Integer)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(2; "Expense Report No. Sequence"; Code[30])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(3; "Posted Expense Report No. Sequence"; Code[30])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(4; "Enable Expense Agent"; Boolean)
+        {
+            DataClassification = ToBeClassified;
+        }
+    }
+    keys
+    {
+        key(PK; "Setup Id")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/src/Tables/ExpenseParticipants.al
+++ b/src/Tables/ExpenseParticipants.al
@@ -1,0 +1,31 @@
+table 50113 "Expense Participants"
+{
+    DataClassification = ToBeClassified;
+    fields
+    {
+        field(1; "Participant Id"; BigInteger)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(2; "Line Id"; BigInteger)
+        {
+            DataClassification = ToBeClassified;
+            TableRelation = "Expense Report Lines"."Line Id";
+        }
+        field(3; "Participant Name"; Text[255])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(4; "Participant Type"; Code[30])
+        {
+            DataClassification = ToBeClassified;
+        }
+    }
+    keys
+    {
+        key(PK; "Participant Id")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/src/Tables/ExpensePolicies.al
+++ b/src/Tables/ExpensePolicies.al
@@ -1,0 +1,50 @@
+table 50114 "Expense Policies"
+{
+    DataClassification = ToBeClassified;
+    fields
+    {
+        field(1; "Policy Id"; BigInteger)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(2; "Expense Category Code"; Code[20])
+        {
+            DataClassification = ToBeClassified;
+            TableRelation = "Expense Categories"."Category Code";
+        }
+        field(3; "Expense Location Code"; Code[10])
+        {
+            DataClassification = ToBeClassified;
+            TableRelation = "Expense Locations"."Location Code";
+        }
+        field(4; "Condition Expression"; Text[1000])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(5; "Receipt Required"; Boolean)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(6; "Daily Limit Amount"; Decimal)
+        {
+            DataClassification = ToBeClassified;
+            DecimalPlaces = 0 : 2;
+            BlankZero = true;
+        }
+        field(7; "Effective From"; Date)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(8; "Effective To"; Date)
+        {
+            DataClassification = ToBeClassified;
+        }
+    }
+    keys
+    {
+        key(PK; "Policy Id")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/src/Tables/ExpensePostingGroups.al
+++ b/src/Tables/ExpensePostingGroups.al
@@ -1,0 +1,30 @@
+table 50115 "Expense Posting Groups"
+{
+    DataClassification = ToBeClassified;
+    fields
+    {
+        field(1; "Posting Group Code"; Code[20])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(2; "Refundable Debit Account"; Code[25])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(3; "Non Refundable Debit Account"; Code[25])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(4; "Prepayment Credit Account"; Code[25])
+        {
+            DataClassification = ToBeClassified;
+        }
+    }
+    keys
+    {
+        key(PK; "Posting Group Code")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/src/Tables/ExpenseReceipts.al
+++ b/src/Tables/ExpenseReceipts.al
@@ -1,0 +1,46 @@
+table 50109 "Expense Receipts"
+{
+    DataClassification = ToBeClassified;
+    fields
+    {
+        field(1; "Receipt Id"; BigInteger)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(2; "Line Id"; BigInteger)
+        {
+            DataClassification = ToBeClassified;
+            TableRelation = "Expense Report Lines"."Line Id";
+        }
+        field(3; "File Name"; Text[255])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(4; "File Uri"; Text[500])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(5; "Uploaded Date Time"; DateTime)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(6; "Amount On Receipt"; Decimal)
+        {
+            DataClassification = ToBeClassified;
+            DecimalPlaces = 0 : 2;
+            BlankZero = true;
+        }
+        field(7; "Currency Code"; Code[3])
+        {
+            DataClassification = ToBeClassified;
+            BlankZero = true;
+        }
+    }
+    keys
+    {
+        key(PK; "Receipt Id")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/src/Tables/ExpenseReportLines.al
+++ b/src/Tables/ExpenseReportLines.al
@@ -1,0 +1,101 @@
+table 50103 "Expense Report Lines"
+{
+    DataClassification = ToBeClassified;
+    fields
+    {
+        field(1; "Line Id"; BigInteger)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(2; "Report Id"; Code[30])
+        {
+            DataClassification = ToBeClassified;
+            TableRelation = "Expense Reports"."Report Id";
+        }
+        field(3; "Line Number"; Integer)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(4; "Expense Date"; Date)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(5; "Category Code"; Code[20])
+        {
+            DataClassification = ToBeClassified;
+            TableRelation = "Expense Categories"."Category Code";
+        }
+        field(6; "Subcategory Code"; Code[20])
+        {
+            DataClassification = ToBeClassified;
+            TableRelation = "Expense Subcategories"."Subcategory Code";
+        }
+        field(7; "Currency Code"; Code[3])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(8; Amount; Decimal)
+        {
+            DataClassification = ToBeClassified;
+            DecimalPlaces = 0 : 2;
+        }
+        field(9; "Tax Amount"; Decimal)
+        {
+            DataClassification = ToBeClassified;
+            DecimalPlaces = 0 : 2;
+            BlankZero = true;
+        }
+        field(10; "Reimbursable Amount"; Decimal)
+        {
+            DataClassification = ToBeClassified;
+            DecimalPlaces = 0 : 2;
+        }
+        field(11; "Expense Location Code"; Code[10])
+        {
+            DataClassification = ToBeClassified;
+            TableRelation = "Expense Locations"."Location Code";
+        }
+        field(12; "Payment Method Code"; Code[10])
+        {
+            DataClassification = ToBeClassified;
+            TableRelation = PaymentMethods."Payment Method Code";
+        }
+        field(13; "Receipt Required"; Boolean)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(14; Description; Text[255])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(15; "Project Id"; Code[30])
+        {
+            DataClassification = ToBeClassified;
+            BlankZero = true;
+        }
+        field(16; "Customer Account"; Code[30])
+        {
+            DataClassification = ToBeClassified;
+            BlankZero = true;
+        }
+        field(17; "Vendor Account"; Code[30])
+        {
+            DataClassification = ToBeClassified;
+            BlankZero = true;
+        }
+        field(18; Status; Code[30])
+        {
+            DataClassification = ToBeClassified;
+        }
+    }
+    keys
+    {
+        key(PK; "Line Id")
+        {
+            Clustered = true;
+        }
+        key(LineNo; "Report Id", "Line Number")
+        {
+        }
+    }
+}

--- a/src/Tables/ExpenseReports.al
+++ b/src/Tables/ExpenseReports.al
@@ -1,0 +1,78 @@
+table 50102 "Expense Reports"
+{
+    DataClassification = ToBeClassified;
+    fields
+    {
+        field(1; "Report Id"; Code[30])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(2; "Employee Id"; Code[20])
+        {
+            DataClassification = ToBeClassified;
+            TableRelation = Employees."Employee Id";
+        }
+        field(3; Purpose; Text[255])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(4; Destination; Text[100])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(5; "Report Date"; Date)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(6; "Posting Date"; Date)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(7; "Currency Code"; Code[3])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(8; "Total Amount"; Decimal)
+        {
+            DataClassification = ToBeClassified;
+            DecimalPlaces = 0 : 2;
+        }
+        field(9; Status; Code[30])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(10; "Payment Method Code"; Code[10])
+        {
+            DataClassification = ToBeClassified;
+            TableRelation = PaymentMethods."Payment Method Code";
+        }
+        field(11; "Pre Approval Number"; Code[30])
+        {
+            DataClassification = ToBeClassified;
+            BlankZero = true;
+        }
+        field(12; "Receipts Attached"; Boolean)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(13; "Created By"; Code[20])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(14; "Created Date Time"; DateTime)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(15; "Modified Date Time"; DateTime)
+        {
+            DataClassification = ToBeClassified;
+        }
+    }
+    keys
+    {
+        key(PK; "Report Id")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/src/Tables/ExpenseSubcategories.al
+++ b/src/Tables/ExpenseSubcategories.al
@@ -1,0 +1,36 @@
+table 50105 "Expense Subcategories"
+{
+    DataClassification = ToBeClassified;
+    fields
+    {
+        field(1; "Subcategory Code"; Code[20])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(2; "Category Code"; Code[20])
+        {
+            DataClassification = ToBeClassified;
+            TableRelation = "Expense Categories"."Category Code";
+        }
+        field(3; Description; Text[255])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(4; Refundable; Boolean)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(5; Active; Boolean)
+        {
+            DataClassification = ToBeClassified;
+            InitValue = true;
+        }
+    }
+    keys
+    {
+        key(PK; "Subcategory Code")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/src/Tables/PaymentMethods.al
+++ b/src/Tables/PaymentMethods.al
@@ -1,0 +1,26 @@
+table 50108 "Payment Methods"
+{
+    DataClassification = ToBeClassified;
+    fields
+    {
+        field(1; "Payment Method Code"; Code[10])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(2; Description; Text[100])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(3; "Company Paid"; Boolean)
+        {
+            DataClassification = ToBeClassified;
+        }
+    }
+    keys
+    {
+        key(PK; "Payment Method Code")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/src/Tables/PerDiemExpenses.al
+++ b/src/Tables/PerDiemExpenses.al
@@ -1,0 +1,47 @@
+table 50110 "Per Diem Expenses"
+{
+    DataClassification = ToBeClassified;
+    fields
+    {
+        field(1; "Per Diem Id"; BigInteger)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(2; "Line Id"; BigInteger)
+        {
+            DataClassification = ToBeClassified;
+            TableRelation = "Expense Report Lines"."Line Id";
+        }
+        field(3; "Employee Id"; Code[20])
+        {
+            DataClassification = ToBeClassified;
+            TableRelation = Employees."Employee Id";
+        }
+        field(4; "Expense Date"; Date)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(5; "Expense Location Code"; Code[10])
+        {
+            DataClassification = ToBeClassified;
+            TableRelation = "Expense Locations"."Location Code";
+        }
+        field(6; "Daily Rate"; Decimal)
+        {
+            DataClassification = ToBeClassified;
+            DecimalPlaces = 0 : 2;
+        }
+        field(7; "Itemized Amount"; Decimal)
+        {
+            DataClassification = ToBeClassified;
+            DecimalPlaces = 0 : 2;
+        }
+    }
+    keys
+    {
+        key(PK; "Per Diem Id")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/src/Tables/PostedExpenseReportHeaders.al
+++ b/src/Tables/PostedExpenseReportHeaders.al
@@ -1,0 +1,40 @@
+table 50117 "Posted Expense Report Headers"
+{
+    DataClassification = ToBeClassified;
+    fields
+    {
+        field(1; "Posted Report Id"; Code[30])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(2; "Report Id"; Code[30])
+        {
+            DataClassification = ToBeClassified;
+            TableRelation = "Expense Reports"."Report Id";
+        }
+        field(3; "Employee Id"; Code[20])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(4; "Posted Date"; Date)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(5; "Currency Code"; Code[3])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(6; "Total Amount"; Decimal)
+        {
+            DataClassification = ToBeClassified;
+            DecimalPlaces = 0 : 2;
+        }
+    }
+    keys
+    {
+        key(PK; "Posted Report Id")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/src/Tables/PostedExpenseReportLines.al
+++ b/src/Tables/PostedExpenseReportLines.al
@@ -1,0 +1,43 @@
+table 50118 "Posted Expense Report Lines"
+{
+    DataClassification = ToBeClassified;
+    fields
+    {
+        field(1; "Posted Report Id"; Code[30])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(2; "Line Number"; Integer)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(3; "Employee Id"; Code[20])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(4; "Category Code"; Code[20])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(5; Amount; Decimal)
+        {
+            DataClassification = ToBeClassified;
+            DecimalPlaces = 0 : 2;
+        }
+        field(6; "Currency Code"; Code[3])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(7; "Expense Location Code"; Code[10])
+        {
+            DataClassification = ToBeClassified;
+        }
+    }
+    keys
+    {
+        key(PK; "Posted Report Id", "Line Number")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/src/app.json
+++ b/src/app.json
@@ -1,0 +1,13 @@
+{
+  "id": "7367eeaf-394a-458d-bf39-5862ef58f523",
+  "name": "Expense Management",
+  "publisher": "Prototype",
+  "version": "1.0.0.0",
+  "brief": "Expense report management extension",
+  "description": "Extension providing tables for expense report management.",
+  "platform": "23.0.0.0",
+  "application": "23.0.0.0",
+  "idRanges": [
+    { "from": 50100, "to": 50199 }
+  ]
+}


### PR DESCRIPTION
## Summary
- implement Expense Management extension skeleton
- define tables for employees, expense reports and related entities
- configure AL-Go settings and workspace

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6880bf6b43c88322acf9167f8923480e