### PR TITLE
Fix object references and shorten field name

### DIFF
--- a/src/Pages/ExpenseManagementSetupCard.al
+++ b/src/Pages/ExpenseManagementSetupCard.al
@@ -13,7 +13,7 @@ page 50168 "Expense Management Setup"
             {
                 field("Setup Id"; "Setup Id") { ApplicationArea = All; }
                 field("Expense Report No. Sequence"; "Expense Report No. Sequence") { ApplicationArea = All; }
-                field("Posted Expense Report No. Sequence"; "Posted Expense Report No. Sequence") { ApplicationArea = All; }
+                field("Posted Expense Report No Seq."; "Posted Expense Report No Seq.") { ApplicationArea = All; }
                 field("Enable Expense Agent"; "Enable Expense Agent") { ApplicationArea = All; }
             }
         }

--- a/src/Tables/ExpenseManagementSetup.al
+++ b/src/Tables/ExpenseManagementSetup.al
@@ -13,7 +13,7 @@ table 50100 "Expense Management Setup"
             Caption = 'Expense Report No. Sequence';
             DataClassification = ToBeClassified;
         }
-        field(3; "Posted Expense Report No. Sequence"; Code[30])
+        field(3; "Posted Expense Report No Seq."; Code[30])
         {
             Caption = 'Posted Expense Report No. Sequence';
             DataClassification = ToBeClassified;

--- a/src/Tables/ExpenseReportLines.al
+++ b/src/Tables/ExpenseReportLines.al
@@ -71,7 +71,7 @@ table 50103 "Expense Report Lines"
         {
             Caption = 'Payment Method Code';
             DataClassification = ToBeClassified;
-            TableRelation = PaymentMethods."Payment Method Code";
+            TableRelation = "Payment Methods"."Payment Method Code";
         }
         field(13; "Receipt Required"; Boolean)
         {

--- a/src/Tables/ExpenseReports.al
+++ b/src/Tables/ExpenseReports.al
@@ -55,7 +55,7 @@ table 50102 "Expense Reports"
         {
             Caption = 'Payment Method Code';
             DataClassification = ToBeClassified;
-            TableRelation = PaymentMethods."Payment Method Code";
+            TableRelation = "Payment Methods"."Payment Method Code";
         }
         field(11; "Pre Approval Number"; Code[30])
         {


### PR DESCRIPTION
## Summary
- fix table relation references to Payment Methods
- shorten Posted Expense Report field to avoid length warning

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883cbbbfd3c8322bc9f1104884d01cf