### PR TITLE
Fix artifact naming failure

### DIFF
--- a/.github/workflows/_BuildALGoProject.yaml
+++ b/.github/workflows/_BuildALGoProject.yaml
@@ -194,6 +194,14 @@ jobs:
           project: ${{ inputs.project }}
           buildMode: ${{ inputs.buildMode }}
 
+      - name: Ensure Settings
+        if: success() || failure()
+        run: |
+          if (-not $env:Settings) {
+            Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value 'Settings={}'
+          }
+        shell: ${{ inputs.shell }}
+
       - name: Calculate Artifact names
         id: calculateArtifactsNames
         uses: microsoft/AL-Go-Actions/CalculateArtifactNames@v7.2


### PR DESCRIPTION
## Summary
- add fallback step to populate `Settings` env var before calculating artifact names

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884e195b0008322b150afb34d2f799c