### PR TITLE
Fix #11: Make expense reports list non-editable

### DIFF
--- a/src/ExpenseReportsList.Page.al
+++ b/src/ExpenseReportsList.Page.al
@@ -4,6 +4,10 @@ page 50152 "Expense Reports List"
     SourceTable = "Expense Reports";
     ApplicationArea = All;
     UsageCategory = Lists;
+    Editable = false;
+    InsertAllowed = false;
+    ModifyAllowed = false;
+    DeleteAllowed = false;
 
     layout
     {


### PR DESCRIPTION
This PR addresses GitHub issue #11 by making the expense reports list grid non-editable.

## Changes Made
- Added `Editable = false` to the Expense Reports List page
- Added `InsertAllowed = false`, `ModifyAllowed = false`, `DeleteAllowed = false` properties
- Ensures the grid functions as a read-only view
- Users can only create new expense reports via the 'New Expense Report' button

## Testing
- ✅ Code compiles successfully with no errors
- ✅ Page properties correctly prevent grid editing
- ✅ 'New Expense Report' button remains functional as a single action (not split button)
- ✅ No breaking changes to existing functionality

Fixes #11